### PR TITLE
문자 컬럼(varchar, char) 길이 타입 기본 설정 변경(byte->char)

### DIFF
--- a/src/com/tmax/tibero/hibernate/dialect/TiberoDialect.java
+++ b/src/com/tmax/tibero/hibernate/dialect/TiberoDialect.java
@@ -105,8 +105,8 @@ public class TiberoDialect extends Dialect {
     }
 
     protected void registerCharacterTypeMappings() {
-        registerColumnType(1, "char(1)");
-        registerColumnType(12, 4000L, "varchar2($l)");
+        registerColumnType(1, "char(1 char)");
+        registerColumnType(12, 4000L, "varchar2($l char)");
         registerColumnType(12, "long");
         registerColumnType(-9, "nvarchar2($l)");
         registerColumnType(-16, "nvarchar2($l)");


### PR DESCRIPTION
<현상>
티베로에서는 hibernate 3, 4의 dialect에서도 문자 컬럼(varchar, char) char 길이로 기본 설정이 되고 있었으나 
hibernate 5에서 기본 설정 길이가 byte로 변경이 됨.
기존 사용자들의 사용성에 불편을 야기할 수 있다고 생각이 들어 char 길이로 유지하는 것이 맞다고 판단함.
<원인>
.
<해결>
byte -> char 길이로 변경함.